### PR TITLE
Create per-year status table for VTRMC

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,59 @@ For the benefit of educators and organizers of math contest practice sessions,
 I am including each problem in a separate file, to make it easy to
 mix-and-match combinations of problems for student practice sessions.
 
-**Disclaimer:** these are my personal solutions, and they have not been
+_**Disclaimer:** these are my personal solutions, and they have not been
 reviewed, so be careful relying on them as there might be errors. Some of these
 competitions may have canonical solutions from the publishers of the problems
 which you may wish to refer to instead if you're looking for verified
-solutions.
+solutions._
 
 ## Contests
 
 * [Virginia Tech Regional Math Contest](vtrmc)
+
+## Compiling $\LaTeX$ to PDF
+
+First, install required packages for building with LuaLaTeX (tested on Ubuntu
+20.04):
+
+```sh
+sudo apt install \
+    texlive-latex-base \
+    texlive-latex-extra \
+    texlive-latex-recommended
+```
+
+> Note: if the set of packages is out-of-date, check the [workflow]
+> ([status][workflow-status]) to see what it's doing, as that is run on every
+> pull request, and I aim to keep it working.
+
+In any contest directory directory with `*.tex` files, you can run any of the
+following commands (though if I haven't published solutions yet, that specific
+command will fail):
+
+* Build both problem set and solutions:
+
+  ```
+  make
+  ```
+
+* Build just the problem set:
+
+  ```
+  make problems
+  ```
+
+* Build just the solutions:
+
+  ```
+  make solutions
+  ```
+
+* Clean up temporary outputs:
+
+  ```
+  make clean
+  ```
 
 ## Contributing
 
@@ -31,3 +75,6 @@ The contest authors retain copyright of their problem sets.
 My original solutions are provided under the Creative Commons Attribution 4.0
 International license (CC-BY-4.0); see [`LICENSE.txt`](LICENSE.txt) for
 details.
+
+[workflow]: .github/workflows/build.yml
+[workflow-status]: https://github.com/mbrukman/math-contests/actions/workflows/build.yml?query=branch%3Amain

--- a/vtrmc/1979/README.md
+++ b/vtrmc/1979/README.md
@@ -1,25 +1,7 @@
 # Virginia Tech Regional Math Contest 1979
 
-Build both problem set and solutions:
+For common build instructions, please see the [top-level project
+`README.md`](../../README.md).
 
-```
-make
-```
-
-Build just the problem set:
-
-```
-make problems
-```
-
-Build just the solutions:
-
-```
-make solutions
-```
-
-Clean up temporary outputs:
-
-```
-make clean
-```
+For the status of solutions for this and other years of this contest, see the
+[VTRMC `README.md`](../README.md).

--- a/vtrmc/README.md
+++ b/vtrmc/README.md
@@ -1,3 +1,17 @@
 # Virginia Tech Regional Math Contest
 
-* [1979](1979)
+Legend:
+
+* 1–8 are problem numbers; each VTRMC consists of 8 problems
+* 📝 — I have written up a complete solution
+* ✍️  — I am working on this and/or have a partial solution
+* empty cell — I don't have a solution to this problem yet
+
+Click on the year to see the problem set and my solutions (depending on the
+icons present in that row):
+
+|        | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 |
+|--------|---|---|---|---|---|---|---|---|
+| [1979] |   | 📝|   |   | 📝|   |   |   |
+
+[1979]: 1979


### PR DESCRIPTION
Also move common build instructions to top-level README to reuse them across
VTRMC years and multiple contests.

We can [skip ci] since we're not changing any code.