### PR TITLE
Factor out common parts of problems and solutions

### DIFF
--- a/vtrmc/1979/Makefile
+++ b/vtrmc/1979/Makefile
@@ -5,14 +5,16 @@ endif
 
 all: problems solutions
 
-PROBLEMS_TEX := $(wildcard ../../third_party/vtrmc/1979/problem?.tex)
+COMMON_TEX = ../common.tex
+
+PROBLEMS_TEX := $(wildcard ../../third_party/vtrmc/1979/problem?.tex) $(COMMON_TEX)
 
 problems: problems.pdf
 
 problems.pdf: problems.tex $(PROBLEMS_TEX) Makefile
 	$(VERB) lualatex --shell-escape $<
 
-SOLUTIONS_TEX := $(wildcard solution?.tex) ../solutions-disclaimer.tex
+SOLUTIONS_TEX := $(wildcard solution?.tex) $(COMMON_TEX) ../solutions-disclaimer.tex
 
 solutions: solutions.pdf
 

--- a/vtrmc/1979/problems.tex
+++ b/vtrmc/1979/problems.tex
@@ -1,16 +1,6 @@
 \documentclass[10pt]{article}
-\usepackage[margin=1in]{geometry} % smaller margins than default
-\usepackage{hyperref} % enable URL links
-\usepackage[parfill]{parskip} % avoid paragraph indent; skip lines between paragraphs
-\usepackage[shortlabels]{enumitem} % enable easy (a), (b), etc. lists
-\pagenumbering{gobble} % disable page numbering (should fit on one page)
 
-\newcommand{\vtrmc}{https://personal.math.vt.edu/plinnell/Vtregional/}
-\newcommand{\source}{\href{\vtrmc}{\texttt{\vtrmc}}}
-\newcommand{\problem}[1]{\textbf{Problem #1.}}
-
-% Syntax: \input_problem{year}{problem number}
-\newcommand{\inputproblem}[2]{\input{../../third_party/vtrmc/#1/problem#2.tex}}
+\input{../common.tex}
 
 \begin{document}
 

--- a/vtrmc/1979/solutions.tex
+++ b/vtrmc/1979/solutions.tex
@@ -1,18 +1,6 @@
 \documentclass[10pt]{article}
-\usepackage{amsmath}
-\usepackage{amssymb}
-\usepackage[margin=1in]{geometry} % smaller margins than default
-\usepackage{hyperref} % enable URL links
-\usepackage[parfill]{parskip} % avoid paragraph indent; skip lines between paragraphs
-\usepackage[shortlabels]{enumitem} % enable easy (a), (b), etc. lists
-\pagenumbering{gobble} % disable page numbering (should fit on one page)
 
-\newcommand{\problem}[1]{\textbf{Problem #1.}}
-\newcommand{\solution}[1]{\textbf{Solution #1.}}
-
-% Syntax: \input_problem{year}{problem number}
-\newcommand{\inputproblem}[2]{\input{../../third_party/vtrmc/#1/problem#2.tex}}
-
+\input{../common.tex}
 \input{../solutions-disclaimer.tex}
 
 \begin{document}

--- a/vtrmc/1980/Makefile
+++ b/vtrmc/1980/Makefile
@@ -5,14 +5,16 @@ endif
 
 all: problems solutions
 
-PROBLEMS_TEX := $(wildcard ../../third_party/vtrmc/1980/problem?.tex)
+COMMON_TEX = ../common.tex
+
+PROBLEMS_TEX := $(wildcard ../../third_party/vtrmc/1980/problem?.tex) $(COMMON_TEX)
 
 problems: problems.pdf
 
 problems.pdf: problems.tex $(PROBLEMS_TEX) Makefile
 	$(VERB) lualatex --shell-escape $<
 
-SOLUTIONS_TEX := $(wildcard solution?.tex) ../solutions-disclaimer.tex
+SOLUTIONS_TEX := $(wildcard solution?.tex) $(COMMON_TEX) $(COMMON_TEX) ../solutions-disclaimer.tex
 
 solutions: solutions.pdf
 

--- a/vtrmc/1980/problems.tex
+++ b/vtrmc/1980/problems.tex
@@ -1,17 +1,6 @@
 \documentclass[10pt]{article}
-\usepackage{amsmath} % provides \text{}
-\usepackage[margin=1in]{geometry} % smaller margins than default
-\usepackage{hyperref} % enable URL links
-\usepackage[parfill]{parskip} % avoid paragraph indent; skip lines between paragraphs
-\usepackage[shortlabels]{enumitem} % enable easy (a), (b), etc. lists
-\pagenumbering{gobble} % disable page numbering (should fit on one page)
 
-\newcommand{\vtrmc}{https://personal.math.vt.edu/plinnell/Vtregional/}
-\newcommand{\source}{\href{\vtrmc}{\texttt{\vtrmc}}}
-\newcommand{\problem}[1]{\textbf{Problem #1.}}
-
-% Syntax: \input_problem{year}{problem number}
-\newcommand{\inputproblem}[2]{\input{../../third_party/vtrmc/#1/problem#2.tex}}
+\input{../common.tex}
 
 \begin{document}
 

--- a/vtrmc/1980/solutions.tex
+++ b/vtrmc/1980/solutions.tex
@@ -1,18 +1,6 @@
 \documentclass[10pt]{article}
-\usepackage{amsmath}
-\usepackage{amssymb}
-\usepackage[margin=1in]{geometry} % smaller margins than default
-\usepackage{hyperref} % enable URL links
-\usepackage[parfill]{parskip} % avoid paragraph indent; skip lines between paragraphs
-\usepackage[shortlabels]{enumitem} % enable easy (a), (b), etc. lists
-\pagenumbering{gobble} % disable page numbering (should fit on one page)
 
-\newcommand{\problem}[1]{\textbf{Problem #1.}}
-\newcommand{\solution}[1]{\textbf{Solution #1.}}
-
-% Syntax: \input_problem{year}{problem number}
-\newcommand{\inputproblem}[2]{\input{../../third_party/vtrmc/#1/problem#2.tex}}
-
+\input{../common.tex}
 \input{../solutions-disclaimer.tex}
 
 \begin{document}

--- a/vtrmc/common.tex
+++ b/vtrmc/common.tex
@@ -1,0 +1,17 @@
+\usepackage{amsmath} % provides \text{}
+\usepackage{amssymb}
+\usepackage[margin=1in]{geometry} % smaller margins than default
+\usepackage{hyperref} % enable URL links
+\usepackage[parfill]{parskip} % avoid paragraph indent; skip lines between paragraphs
+\usepackage[shortlabels]{enumitem} % enable easy (a), (b), etc. lists
+\pagenumbering{gobble} % disable page numbering (should fit on one page)
+
+\newcommand{\vtrmc}{https://personal.math.vt.edu/plinnell/Vtregional/}
+\newcommand{\source}{\href{\vtrmc}{\texttt{\vtrmc}}}
+
+\newcommand{\problem}[1]{\textbf{Problem #1.}}
+\newcommand{\solution}[1]{\textbf{Solution #1.}}
+
+% Syntax: \input_problem{year}{problem number}
+\newcommand{\inputproblem}[2]{\input{../../third_party/vtrmc/#1/problem#2.tex}}
+


### PR DESCRIPTION
Move common package imports, configuraiton options, and command definitions to a shared `common.tex` that can be imported into each problem and solution file to avoid copy-pasting the same header block into each new file.

Add the new file to the dependency lists in Makefiles.