### PR TITLE
Factor out common Makefile rules into `common.mk`

### DIFF
--- a/vtrmc/1979/Makefile
+++ b/vtrmc/1979/Makefile
@@ -1,25 +1,4 @@
-VERB = @
-ifeq ($(VERBOSE),1)
-	VERB =
-endif
+ROOT = ../..
+YEAR = 1979
 
-all: problems solutions
-
-COMMON_TEX = ../common.tex
-
-PROBLEMS_TEX := $(wildcard ../../third_party/vtrmc/1979/problem?.tex) $(COMMON_TEX)
-
-problems: problems.pdf
-
-problems.pdf: problems.tex $(PROBLEMS_TEX) Makefile
-	$(VERB) lualatex --shell-escape $<
-
-SOLUTIONS_TEX := $(wildcard solution?.tex) $(COMMON_TEX) ../solutions-disclaimer.tex
-
-solutions: solutions.pdf
-
-solutions.pdf: solutions.tex $(PROBLEMS_TEX) $(SOLUTIONS_TEX) Makefile
-	$(VERB) lualatex --shell-escape $<
-
-clean:
-	$(VERB) rm -f *.aux *.dvi *.log *.out *.pdf
+include ../common.mk

--- a/vtrmc/1980/Makefile
+++ b/vtrmc/1980/Makefile
@@ -1,25 +1,4 @@
-VERB = @
-ifeq ($(VERBOSE),1)
-	VERB =
-endif
+ROOT = ../..
+YEAR = 1980
 
-all: problems solutions
-
-COMMON_TEX = ../common.tex
-
-PROBLEMS_TEX := $(wildcard ../../third_party/vtrmc/1980/problem?.tex) $(COMMON_TEX)
-
-problems: problems.pdf
-
-problems.pdf: problems.tex $(PROBLEMS_TEX) Makefile
-	$(VERB) lualatex --shell-escape $<
-
-SOLUTIONS_TEX := $(wildcard solution?.tex) $(COMMON_TEX) $(COMMON_TEX) ../solutions-disclaimer.tex
-
-solutions: solutions.pdf
-
-solutions.pdf: solutions.tex $(PROBLEMS_TEX) $(SOLUTIONS_TEX) Makefile
-	$(VERB) lualatex --shell-escape $<
-
-clean:
-	$(VERB) rm -f *.aux *.dvi *.log *.out *.pdf
+include ../common.mk

--- a/vtrmc/common.mk
+++ b/vtrmc/common.mk
@@ -1,0 +1,25 @@
+VERB = @
+ifeq ($(VERBOSE),1)
+	VERB =
+endif
+
+all: problems solutions
+
+COMMON_TEX = $(ROOT)/vtrmc/common.tex
+
+PROBLEMS_TEX := $(wildcard $(ROOT)/third_party/vtrmc/$(YEAR)/problem?.tex) $(COMMON_TEX)
+
+problems: problems.pdf
+
+problems.pdf: problems.tex $(PROBLEMS_TEX) Makefile
+	$(VERB) lualatex --shell-escape $<
+
+SOLUTIONS_TEX := $(wildcard solution?.tex) $(COMMON_TEX) $(COMMON_TEX) $(ROOT)/vtrmc/solutions-disclaimer.tex
+
+solutions: solutions.pdf
+
+solutions.pdf: solutions.tex $(PROBLEMS_TEX) $(SOLUTIONS_TEX) Makefile
+	$(VERB) lualatex --shell-escape $<
+
+clean:
+	$(VERB) rm -f *.aux *.dvi *.log *.out *.pdf


### PR DESCRIPTION
This enables better reuse of common Makefile structures for additional problem sets and solutions without duplication.