### PR TITLE
Split LaTeX and Typst into separate builds

### DIFF
--- a/.github/workflows/latex.yaml
+++ b/.github/workflows/latex.yaml
@@ -1,0 +1,60 @@
+name: LaTeX
+
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+        # All LaTeX files and associated Makefiles, etc.
+      - '**/*.tex'
+      - '**/tex/**'
+        # Relevant CI configs
+      - '.github/workflows/latex.yaml' # this file
+
+  pull_request:
+    branches: [ "main" ]
+    paths:
+        # All LaTeX files and associated Makefiles, etc.
+      - '**/*.tex'
+      - '**/tex/**'
+        # Relevant CI configs
+      - '.github/workflows/latex.yaml' # this file
+
+jobs:
+  build:
+
+    runs-on: 'ubuntu-24.04'
+
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v3
+
+    - name: Install LuaLaTeX
+      run: |
+        sudo apt install -qq -y \
+            texlive-latex-base \
+            texlive-latex-extra \
+            texlive-latex-recommended
+
+    - name: Build *.tex files to PDFs
+      run: |
+        cd vtrmc/tex
+        for year in [1-9]* ; do
+          # The begin/end markers enable having collapsible sections in the
+          # output, which improves readability.
+          #
+          # See the docs for details:
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+
+          echo "::group::VTRMC ${year} problems"
+          make -C "${year}" problems
+          echo "::endgroup::"
+
+          echo "::group::VTRMC ${year} solutions"
+          make -C "${year}" solutions
+          echo "::endgroup::"
+        done
+      env:
+        VERBOSE: 1

--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -1,47 +1,34 @@
-name: Build
+name: Typst
 
+# GitHub Actions does not support anchors:
+# https://github.com/actions/runner/issues/1182
+# so we need to duplicate paths below and manually keep them in sync.
 on:
   push:
     branches: [ "main" ]
+    paths:
+        # All Typst files and associated Makefiles, etc.
+      - '**/*.typ'
+      - '**/typ/**'
+        # Relevant CI configs
+      - '.github/workflows/typst.yaml' # this file
   pull_request:
     branches: [ "main" ]
+    paths:
+        # All Typst files and associated Makefiles, etc.
+      - '**/*.typ'
+      - '**/typ/**'
+        # Relevant CI configs
+      - '.github/workflows/typst.yaml' # this file
 
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-24.04'
 
     steps:
     - name: Checkout repo
       uses: actions/checkout@v3
-
-    - name: Install LuaLaTeX
-      run: |
-        sudo apt install -qq -y \
-            texlive-latex-base \
-            texlive-latex-extra \
-            texlive-latex-recommended
-
-    - name: Build *.tex files to PDFs
-      run: |
-        cd vtrmc/tex
-        for year in [1-9]* ; do
-          # The begin/end markers enable having collapsible sections in the
-          # output, which improves readability.
-          #
-          # See the docs for details:
-          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
-
-          echo "::group::VTRMC ${year} problems"
-          make -C "${year}" problems
-          echo "::endgroup::"
-
-          echo "::group::VTRMC ${year} solutions"
-          make -C "${year}" solutions
-          echo "::endgroup::"
-        done
-      env:
-        VERBOSE: 1
 
     - name: Install Typst
       run: |
@@ -57,6 +44,12 @@ jobs:
       run: |
         cd vtrmc/typ
         for year in [1-9]* ; do
+          # The begin/end markers enable having collapsible sections in the
+          # output, which improves readability.
+          #
+          # See the docs for details:
+          # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
+
           echo "::group::VTRMC ${year} problems"
           make -C "${year}" problems
           echo "::endgroup::"


### PR DESCRIPTION
This way, we can easily run a subset of the builds depending on the changed files in a PR and avoid extra work.

Also specified which files are relevant for each build separately.

Switched OS from `ubuntu-latest` to latest version `ubuntu-24.04`.