### PR TITLE
Update to Typst 0.12.0

### DIFF
--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -38,8 +38,13 @@ jobs:
         tar xf "${TYPST_BUILD}.tar.xz"
         echo "${PWD}/${TYPST_BUILD}" >> "${GITHUB_PATH}"
       env:
-        TYPST_VERSION: v0.6.0
+        TYPST_VERSION: v0.12.0
         TYPST_BUILD: typst-x86_64-unknown-linux-musl
+
+    - name: Show Typst version
+      run: |
+        echo "Typst version:"
+        typst --version
 
     - name: Build *.typ files to PDFs
       run: |

--- a/README.md
+++ b/README.md
@@ -25,26 +25,27 @@ refer to instead if you're looking for verified solutions._
 
 * [Virginia Tech Regional Math Contest](vtrmc)
 
-## Compiling $\LaTeX$ to PDF
+## Install LuaLaTeX
 
-First, install required packages for building with LuaLaTeX (tested on Ubuntu
-24.04):
+Install required packages for building with LuaLaTeX; see our [LaTeX
+workflow][latex-workflow] ([status][latex-workflow-status]) to see how we
+install it.
 
-```sh
-sudo apt install \
-    texlive-latex-base \
-    texlive-latex-extra \
-    texlive-latex-recommended
-```
+## Install Typst
+
+[Install Typst][install-typst] as appropriate for your platform. For
+reference, you can see how we install it in the [Typst workflow][typst-workflow].
 
 > [!NOTE]
-> If the set of packages is out-of-date, check the [workflow]
-> ([status][workflow-status]) to see what it's doing, as that is run on every
-> pull request, and I aim to keep it working.
+> The files in this repository are currently compatible with the Typst version
+> listed in the [Typst workflow][typst-workflow]. Assuming our [build is
+> green][typst-workflow-status], if you have trouble building the files, please
+> make sure you're using the same version as we are.
 
-In any contest directory directory with `*.tex` files, you can run any of the
-following commands (though if I haven't published solutions yet, that specific
-command will fail):
+## Building PDFs
+
+In any contest directory (outside of `third_party`) with `*.tex` or `*.typ`
+files, you can run any of the following commands:
 
 * Build both problem set and solutions:
 
@@ -84,5 +85,8 @@ My original solutions are provided under the Creative Commons Attribution 4.0
 International license (CC-BY-4.0); see [`LICENSE.txt`](LICENSE.txt) for
 details.
 
-[workflow]: .github/workflows/latex.yaml
-[workflow-status]: https://github.com/mbrukman/math-contests/actions/workflows/latex.yaml?query=branch%3Amain
+[install-typst]: https://github.com/typst/typst?tab=readme-ov-file#installation
+[latex-workflow]: .github/workflows/latex.yaml
+[latex-workflow-status]: https://github.com/mbrukman/math-contests/actions/workflows/latex.yaml?query=branch%3Amain
+[typst-workflow]: .github/workflows/typst.yaml
+[latex-workflow-status]: https://github.com/mbrukman/math-contests/actions/workflows/typst.yaml?query=branch%3Amain

--- a/vtrmc/typ/1979/solution5.typ
+++ b/vtrmc/typ/1979/solution5.typ
@@ -1,5 +1,5 @@
-// Define "maybe congruent" with a question mark above the `ident`.
-#let mbeq = $limits(ident)^?$
+// Define "maybe congruent" with a question mark above the `equiv`.
+#let mbeq = $limits(equiv)^?$
 
 We can demonstrate this via induction. Recall that to prove something by
 induction, we have two steps:
@@ -26,7 +26,7 @@ Now let's consider the inductive case:
 Note that we can assume that:
 
 $
-  3^(4n + 2) + 5^(2n + 1) ident 0 mod 14 "(1)"
+  3^(4n + 2) + 5^(2n + 1) equiv 0 mod 14 "(1)"
 $
 
 Let's start with the second point:
@@ -48,8 +48,8 @@ $
                                         & "factor out" 25 \
 56 dot 3^(4n + 2)                       & mbeq 0 mod 14
                                         & "using eq." 1 \
-0                                       & ident 0 mod 14
-                                        & "since" 56 ident 0 mod 14 \
+0                                       & equiv 0 mod 14
+                                        & "since" 56 equiv 0 mod 14 \
 $
 
 Above, we were able to first subtract the expression $25 dot (3^(4n + 2) +

--- a/vtrmc/typ/common.mk
+++ b/vtrmc/typ/common.mk
@@ -15,12 +15,12 @@ problems: problems.pdf
 PROBLEMS = $(ROOT)/third_party/vtrmc/typ/$(YEAR)/problem?.typ
 
 problems.pdf: problems.typ problem?.typ $(PROBLEMS) $(TYPST_DEPS) $(MAKEFILE_DEPS)
-	$(VERB) $(TYPST) --root="$(ROOT)" compile $< $@
+	$(VERB) $(TYPST) compile --root="$(ROOT)" $< $@
 
 solutions: solutions.pdf
 
 solutions.pdf: solutions.typ solution?.typ $(PROBLEMS) $(TYPST_DEPS) $(MAKEFILE_DEPS)
-	$(VERB) $(TYPST) --root="$(ROOT)" compile $< $@
+	$(VERB) $(TYPST) compile --root="$(ROOT)" $< $@
 
 clean:
 	$(VERB) rm -f problems.pdf solutions.pdf


### PR DESCRIPTION
Typst changes required due to upgrade from 0.6.0 to 0.12.0:

* `ident` is not a valid symbol, now use `equiv`
* flag `--root` must be after the `compile` command on the CLI

README updates:

* removed LaTeX `apt install` command; refer to workflow
* added section for installing Typst, also refer to workflow