### PR TITLE
Update actions/checkout to v5

### DIFF
--- a/.github/workflows/latex.yaml
+++ b/.github/workflows/latex.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Install LuaLaTeX
       run: |

--- a/.github/workflows/typst.yaml
+++ b/.github/workflows/typst.yaml
@@ -31,7 +31,7 @@ jobs:
 
     steps:
     - name: Checkout repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v5
 
     - name: Install Typst
       run: |
@@ -59,11 +59,19 @@ jobs:
           # https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines
 
           echo "::group::VTRMC ${year} problems"
-          make -C "${year}" problems
+          make -C "${year}" problems || {
+            EXIT_CODE=$?
+            echo "::error::VTRMC ${year} problems failed"
+            echo "VTRMC ${year} problems failed" >> "${GITHUB_STEP_SUMMARY}"
+          }
           echo "::endgroup::"
 
           echo "::group::VTRMC ${year} solutions"
-          make -C "${year}" solutions
+          make -C "${year}" solutions || {
+            EXIT_CODE=$?
+            echo "::error::VTRMC ${year} solutions failed"
+            echo "VTRMC ${year} solutions failed" >> "${GITHUB_STEP_SUMMARY}"
+          }
           echo "::endgroup::"
         done
       env:


### PR DESCRIPTION
Also add error handling and reporting to Typst workflow to match LaTeX so that it runs as many years as possible and reports all years at the end together, rather than stopping at the first error.