### PR TITLE
Update href pkg in `solutions-disclaimer.tex`

### DIFF
--- a/vtrmc/tex/solutions-disclaimer.tex
+++ b/vtrmc/tex/solutions-disclaimer.tex
@@ -1,8 +1,8 @@
 % Note: this file requires the caller to
 %
-%     \usepackage{href}`
+%     \usepackage{hyperref}
 %
-% before including this file.
+% before including this file, which is already handled in `common.tex`.
 
 \newcommand{\repo}{https://github.com/mbrukman/math-contests}
 \newcommand{\solutions}{https://personal.math.vt.edu/linnell/Vtregional/solutions.pdf}


### PR DESCRIPTION
This is using `hyperref` package, not `href`, which is the name of the command.

Since this is just a comment update, we can [skip ci].